### PR TITLE
Doc patch for minimum versions.

### DIFF
--- a/README
+++ b/README
@@ -23,6 +23,9 @@ DESCRIPTION
     to a true value by the Plack server. If it's set to false, then this
     middleware simply does nothing.
 
+    You must use at least version 0.2006 of Starman, and 0.19 of Starlet.  Earlier
+    versions ignore the flag to stop the process.
+
 CONFIGURATIONS
     max_unshared_size_in_kb
         The maximum amount of *unshared* memory the process can use; usually

--- a/lib/Plack/Middleware/SizeLimit.pm
+++ b/lib/Plack/Middleware/SizeLimit.pm
@@ -79,6 +79,9 @@ This middleware only works when the environment C<psgix.harakiri> is
 set to a true value by the Plack server.  If it's set to false, then this
 middleware simply does nothing.
 
+You must use at least version 0.2006 of Starman, and 0.19 of Starlet.  Earlier versions
+ignore the flag to stop the process.
+
 =head1 CONFIGURATIONS
 
 =over 4


### PR DESCRIPTION
I spent most of a weekend trying to setup size limiting only to find out tonight that our ancient version of Starman didn't use the harakiri flag.  Hopefully this little doc patch will save some others the time.
