### PR TITLE
Fix Makefile.PL for Perl 5.26+ without PERL_USE_UNSAFE_INC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/Makefile
+/MYMETA.json
+/MYMETA.yml
+/blib/
+/pm_to_blib

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,7 @@
 #!/usr/bin/env perl
+use strict;
+use warnings;
+
 use inc::Module::Package 'Au:dry 1';
 requires 'parent';
 requires 'Plack::Middleware';

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2,7 +2,8 @@
 use strict;
 use warnings;
 
-use inc::Module::Package 'Au:dry 1';
+use lib 'inc/';
+use Module::Package 'Au:dry 1';
 requires 'parent';
 requires 'Plack::Middleware';
 requires 'Process::SizeLimit::Core' => '0.9501';


### PR DESCRIPTION
Since Perl 5.26 `.` is not in `@INC` anymore and statements like `use inc::Module::Package` don't work anymore.

I fixed `Makefile.PL` and added `use strict` and a `.gitignore` file.

`ack 'inc::'` still lists 15 occurrences but tests and install succeeds. I don't know if the remaining occurrences should be changed, too. If anyone thinks so, I volunteer to edit those, too.